### PR TITLE
Clean up spec helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,19 @@ To setup the testing within your profile you will need to create
 a `spec` directory and add the `spec/spec_helper.rb` file found
 in this repository.
 
-Within your `spec/spec_helper.rb` you will need to require all
-the inspec resources defined in the profile's `libraries` directory.
+Within your `spec/spec_helper.rb` or in the individual `spec` test files
+you will need to require all the InSpec resources defined in the profile's
+`libraries` directory.
 
 ```ruby
 require 'inspec'
 require 'rspec/its'
-require 'libraries/ohai.rb'
 
 # To test each of your resources, they will need to be required
-# to have the InSpe registry know about it.
-require 'libraries/ohai.rb'
+# to have the InSpec registry know about it.
+# You can choose to add them here for all of the spec test files or
+# individually in each of the spec test files.
+# require 'libraries/ohai.rb'
 
 # ... rest of the spec_helper.rb ...
 ```
@@ -72,6 +74,9 @@ test, through the `resource` helper.
 
 ```ruby
 require 'spec_helper'
+# To test each of your resources, they will need to be required
+# to have the InSpec registry know about it, if not required in the spec_helper
+# require 'libraries/ohai.rb'
 
 describe_inspec_resource 'ohai' do
   context 'relying on the automatic path' do

--- a/spec/ohai_spec.rb
+++ b/spec/ohai_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'libraries/ohai.rb'
 
 describe_inspec_resource 'ohai' do
 
@@ -30,7 +31,7 @@ describe_inspec_resource 'ohai' do
       context 'nested attributes' do
         environment do
           command('/path/to/ohai').returns(result: {
-            stdout: '{ "cpu": { "cores": 4 } }', exit_status: 0 
+            stdout: '{ "cpu": { "cores": 4 } }', exit_status: 0
           })
         end
 
@@ -44,9 +45,9 @@ describe_inspec_resource 'ohai' do
       # Specifying an attribute as a parameter focuses the ohai run to only
       # that attribute. This makes ohai run quicker as it ignores all other
       # attributes.
-      
+
         # NOTE: Because of the way the environment helper works a let helper will not work:
-        # 
+        #
         # let(:chef_packages_stdout) do
         #   <<~STDOUT
         #     {
@@ -118,7 +119,7 @@ describe_inspec_resource 'ohai' do
     end
 
     context 'with mulitple attribute parameters' do
-      # When you provide multiple attributes as parameters ohai will 
+      # When you provide multiple attributes as parameters ohai will
       # return multiple JSON objects next each other in the output. This
       # requires that the output be correctly partitioned and then assigned
       # back to the parameter that was provided
@@ -142,7 +143,7 @@ describe_inspec_resource 'ohai' do
           stdout: ohai_stdout, exit_status: 0
         })
       end
-      
+
       it 'two attributes are accessible via dot-notation' do
         # NOTE: Initially I thought that when specifying an attribute the interface of the resource
         #   should change so that the attribute name would not have to be repeated. But you can
@@ -213,7 +214,7 @@ describe_inspec_resource 'ohai' do
         })
       end
 
-      it 'fails with error' do        
+      it 'fails with error' do
         expect { resource.os }.to raise_error(OhaiResource::ResultsParsingError)
       end
     end
@@ -225,12 +226,12 @@ describe_inspec_resource 'ohai' do
         command('which ohai').returns(stdout: '')
       end
 
-      it 'fails with error' do        
+      it 'fails with error' do
         expect { resource.os }.to raise_error(OhaiResource::PathCouldNotBeFound)
       end
     end
   end
-  
+
   context 'when a valid path is provided' do
     environment do
       command('/another/path/to/ohai').returns(result: {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,7 @@ shared_context 'InSpec Resource', type: :inspec_resource do
     #   all the environment builders in th current context and their
     #   parent contexts.
     let(:backend) do
-      env_builders = self.class.parent_groups.map { |parent| parent.environment_builder }.compact
+      env_builders = self.class.parent_groups.map(&:environment_builder).compact
       starting_double = RSpec::Mocks::Double.new('backend')
       env_builders.inject(starting_double) { |acc, elem| elem.evaluate(self, acc) }
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,14 @@
 require 'inspec'
 require 'rspec/its'
-require 'libraries/ohai.rb'
 
 # To test each of your resources, they will need to be required
 # to have the InSpe registry know about it.
-# 
+#
 #     require './libraries/ohai.rb'
 
 RSpec.configure do |config|
   #
-  # Add a convienent name for the example group to the RSpec 
+  # Add a convienent name for the example group to the RSpec
   # lexicon. This enables a user to write:
   #     describe_inspec_resource 'ohai'
   #
@@ -26,7 +25,7 @@ shared_context 'InSpec Resource', type: :inspec_resource do
   let(:resource_name) { self.class.top_level_description }
 
   # Find the resource in the registry based on the resource_name.
-  #   The resource classes stored here are not exactly instances 
+  #   The resource classes stored here are not exactly instances
   #   of the Resource class (e.g. OhaiResource). They are
   #   instead wrapped with the backend transport mechanism which
   #   they will be executed against.
@@ -45,7 +44,7 @@ shared_context 'InSpec Resource', type: :inspec_resource do
     environment_builder(DoubleBuilder.new(&block))
 
     # Create a backend helper which will generate a backend double
-    #   based on the definitions that have been building up in 
+    #   based on the definitions that have been building up in
     #   all the environment builders in th current context and their
     #   parent contexts.
     let(:backend) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'inspec'
 require 'rspec/its'
 
 # To test each of your resources, they will need to be required
-# to have the InSpe registry know about it.
+# to have the InSpec registry know about it.
 #
 #     require './libraries/ohai.rb'
 


### PR DESCRIPTION
Here are a couple of changes to the spec_helper file to clean up a few things

1. Instead of including the library file in the `spec_helper.rb` do that in the spec file we will be running.  Makes `spec_helper.rb` more portable and easier to just drop into another project.
2. minor typo, whitespace and map usage cleanup