### PR TITLE
Adds an example and platform helper

### DIFF
--- a/libraries/example.rb
+++ b/libraries/example.rb
@@ -1,0 +1,22 @@
+class ExampleResource < Inspec.resource(1)
+  name 'example'
+
+  def initialize(alternate_path = nil)
+    @path = alternate_path || default_path
+  end
+
+  def default_path
+    if inspec.os.windows?
+      'C:\example\bin\example.bat'
+    else
+      '/usr/bin/example'
+    end
+  end
+
+  attr_reader :path
+
+  def version
+    raw_result = inspec.command("#{path} --version").stdout
+    raw_result.split.first
+  end
+end

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -3,9 +3,12 @@ require 'libraries/example'
 
 describe_inspec_resource 'example' do
   context 'on windows' do
-    let(:platform) { 'windows' }
+    # This helper method here is the equivalent to the first line within the environment
+    #   that defines an os that returns a true when the names align.
+    # let(:platform) { 'windows' }
 
     environment do
+      os.returns(windows?: true)
       command('C:\example\bin\example.bat --version').returns(stdout: '0.1.0 (windows-build)')
     end
 

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'libraries/example'
+
+describe_inspec_resource 'example' do
+  context 'on windows' do
+    let(:platform) { 'windows' }
+
+    environment do
+      command('C:\example\bin\example.bat --version').returns(stdout: '0.1.0 (windows-build)')
+    end
+
+    its(:version) { should eq('0.1.0') }
+  end
+
+  context 'on linux' do
+    let(:platform) { 'linux' }
+
+    environment do
+      command('/usr/bin/example --version').returns(stdout: '0.1.0 (GNULinux-build)')
+    end
+
+    its(:version) { should eq('0.1.0') }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,18 +48,10 @@ shared_context 'InSpec Resource', type: :inspec_resource do
     #   all the environment builders in th current context and their
     #   parent contexts.
     let(:backend) do
-
-      platform_builder = if platform
-        # For all the possible platforms assign a false result unless the platform name matches
-        possible_platforms = %w{aix? redhat? debian? suse? bsd? solaris? linux? unix? windows? hpux? darwin?}
-        os_platform_mock_results = possible_platforms.inject({}) { |acc, elem| acc[elem] = (elem[0..-2] == platform.to_s) ; acc }
-
-        DoubleBuilder.new { os.returns(os_platform_mock_results) }
-      else
-        DoubleBuilder.new do
-          # no-op
-        end
-      end
+      # For all the possible platforms assign a false result unless the platform name matches
+      possible_platforms = %w{aix? redhat? debian? suse? bsd? solaris? linux? unix? windows? hpux? darwin?}
+      os_platform_mock_results = possible_platforms.inject({}) { |acc, elem| acc[elem] = (elem[0..-2] == platform.to_s) ; acc }
+      platform_builder = DoubleBuilder.new { os.returns(os_platform_mock_results) }
 
       env_builders = [ platform_builder ] + self.class.parent_groups.map(&:environment_builder).compact
       starting_double = RSpec::Mocks::Double.new('backend')
@@ -75,6 +67,11 @@ shared_context 'InSpec Resource', type: :inspec_resource do
   # Provide an alias of the resource to subject. By setting the subject
   #   creates an implicit subject to work with the `rspec-its`.
   let(:subject) { resource }
+
+  # Provide a helper to help define the environment where the plugin is run in the unit tests
+  let(:platform) do
+    "spec"
+  end
 
   # This is a no-op backend that should be overridden.
   #   Below is a helper method #environment which provides some

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,8 +49,8 @@ shared_context 'InSpec Resource', type: :inspec_resource do
     #   parent contexts.
     let(:backend) do
       # For all the possible platforms assign a false result unless the platform name matches
-      possible_platforms = %w{aix? redhat? debian? suse? bsd? solaris? linux? unix? windows? hpux? darwin?}
-      os_platform_mock_results = possible_platforms.inject({}) { |acc, elem| acc[elem] = (elem[0..-2] == platform.to_s) ; acc }
+      possible_platforms = %w{aix redhat debian suse bsd solaris linux unix windows hpux darwin}
+      os_platform_mock_results = possible_platforms.inject({}) { |acc, elem| acc["#{elem}?"] = (elem == platform.to_s) ; acc }
       platform_builder = DoubleBuilder.new { os.returns(os_platform_mock_results) }
 
       env_builders = [ platform_builder ] + self.class.parent_groups.map(&:environment_builder).compact


### PR DESCRIPTION
When defining a resource it seems like specifying a platform would be useful for testing in some instances. While this was always possible with:

```ruby
    environment do
      os.returns(windows?: true)
      command('C:\example\bin\example.bat --version').returns(stdout: '0.1.0 (windows-build)')
    end
```

It can now be done with the following:

```ruby
  context 'on windows' do
    let(:platform) { 'windows' }

    environment do
      command('C:\example\bin\example.bat --version').returns(stdout: '0.1.0 (windows-build)')
    end

    its(:version) { should eq('0.1.0') }
  end
```